### PR TITLE
-Changing the tax formular to adress the last changes made by ccp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ Elinor/bin/
 Elinor/obj/
 *.suo
 *.msi
+.vs/

--- a/Elinor/CalculateDataThread.cs
+++ b/Elinor/CalculateDataThread.cs
@@ -43,12 +43,12 @@ namespace Elinor
 
         internal static double NpcBroker(Profile profile)
         {
-            return (3 - (profile.brokerRelations * 0.1 + profile.factionStanding * 0.03 + profile.corpStanding * 0.02)) / 100;
+            return (5 - (profile.brokerRelations * 0.3 + profile.factionStanding * 0.03 + profile.corpStanding * 0.02)) / 100;
         }
 
         internal static double SalesTax(int accounting)
         {
-            return .020*(1 - (accounting*.1));
+            return .050*(1 - (accounting*.11));
         }
 
         internal void Run()

--- a/Elinor/ClipboardTools.cs
+++ b/Elinor/ClipboardTools.cs
@@ -19,6 +19,7 @@ namespace Elinor
 
             while (copied == false && Attempts < 3)
             {
+                Clipboard.Clear();
                 try
                 {
                     Clipboard.SetText(d > .01 ? Math.Round(d, 2).ToString(CultureInfo.InvariantCulture) : string.Empty);

--- a/Elinor/MessageBoxEx.cs
+++ b/Elinor/MessageBoxEx.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Windows.Forms;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using System.Threading;
 
 namespace Elinor
 {
@@ -166,7 +167,7 @@ namespace Elinor
 
             if (_owner != null)
             {
-                _hHook = SetWindowsHookEx(WH_CALLWNDPROCRET, _hookProc, IntPtr.Zero, AppDomain.GetCurrentThreadId());
+                _hHook = SetWindowsHookEx(WH_CALLWNDPROCRET, _hookProc, IntPtr.Zero, Thread.CurrentThread.ManagedThreadId);
             }
         }
 


### PR DESCRIPTION
-Changing the tax formular to adress the last changes made by ccp

The math should be okay, min tax on a npc station is 5.25%.
Broker Relations 5 brings the broker tax down to 3.5%.
Faction and Corp Standing should add a maximum of 0.5%.

Accounting is at a minimum of 2.25% with Accounting 5.

-Clearing the Clipboard before setting new value helps without
throwing CLIPBRD_E_CANT_OPEN everytime you export a new log

My program did freeze then exporting a new market log with auto copy on.
It might be better to use Clipboard.SetDataObject instead of SetText and starting a new background thread for the copying process so it dont freeze the whole program if a exception is thrown.

-Replacing obselete api call call with a new one from the Threading api
The Messagebox class called a obselete api for identifying threads for multiple calls?
-Added vs folder to gitignore